### PR TITLE
Fix tests to find SharpZipLib/Content/test.zip.

### DIFF
--- a/SharpFileSystem.Tests/SharpZipLib/SharpzipLibFileSystemTest.cs
+++ b/SharpFileSystem.Tests/SharpZipLib/SharpzipLibFileSystemTest.cs
@@ -8,6 +8,7 @@ using SharpFileSystem.SharpZipLib;
 namespace SharpFileSystem.Tests.SharpZipLib
 {
     [TestClass]
+    [DeploymentItem("SharpZipLib/Content/test.zip", "SharpZipLib/Content")]
     public class SharpZipLibFileSystemTest
     {
         private FileStream fileStream;

--- a/SharpFileSystem.vsmdi
+++ b/SharpFileSystem.vsmdi
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<TestLists xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
-  <TestList name="Lists of Tests" id="8c43106b-9dc1-4907-a29f-aa66a61bf5b6">
-    <RunConfiguration id="83c4609f-3434-4906-8608-909e5cef81e1" name="Local Test Run" storage="localtestrun.testrunconfig" type="Microsoft.VisualStudio.TestTools.Common.TestRunConfiguration, Microsoft.VisualStudio.QualityTools.Common,   PublicKeyToken=b03f5f7f11d50a3a" />
-  </TestList>
-</TestLists>


### PR DESCRIPTION
Looks like the .vsmdi file is referring to some nonexistent `localtestrun.testrunconfig` file. Thus VS refused to run any tests when I tried to set that as the chosen test settings.

I found that when running the tests with no settings at all, all of the 7-zip tests failed. However, by just adding `[DeployItem]` appropriately, I could get them to stop failing because that would copy the `test.zip` properly. As I think this is cleaner than using test run settings, I removed that `.vsmdi` file.