### PR TITLE
Tests physical memory

### DIFF
--- a/SharpFileSystem.Tests/FileSystems/MemoryFileSystemTest.cs
+++ b/SharpFileSystem.Tests/FileSystems/MemoryFileSystemTest.cs
@@ -1,0 +1,120 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SharpFileSystem.FileSystems;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SharpFileSystem.Tests.FileSystems
+{
+    [TestClass]
+    public class MemoryFileSystemTest
+    {
+        MemoryFileSystem FileSystem { get; set; }
+        FileSystemPath RootFilePath { get; } = FileSystemPath.Root.AppendFile("x");
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            FileSystem = new MemoryFileSystem();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            using (FileSystem) { }
+        }
+
+        [TestMethod]
+        public void CreateFile()
+        {
+            // File shouldn’t exist prior to creation.
+            Assert.IsFalse(FileSystem.Exists(RootFilePath));
+
+            var content = new byte[] { 0xde, 0xad, 0xbe, 0xef, };
+            using (var xStream = FileSystem.CreateFile(RootFilePath))
+            {
+                // File now should exist.
+                Assert.IsTrue(FileSystem.Exists(RootFilePath));
+
+                xStream.Write(content, 0, content.Length);
+            }
+
+            // File should still exist and have content.
+            Assert.IsTrue(FileSystem.Exists(RootFilePath));
+            using (var xStream = FileSystem.OpenFile(RootFilePath, FileAccess.Read))
+            {
+                var readContent = new byte[2 * content.Length];
+                Assert.AreEqual(content.Length, xStream.Read(readContent, 0, readContent.Length));
+                CollectionAssert.AreEqual(
+                    content,
+                    // trim to the length that was read.
+                    readContent.Take(content.Length).ToArray());
+
+                // Trying to read beyond end of file should return 0.
+                Assert.AreEqual(0, xStream.Read(readContent, 0, readContent.Length));
+            }
+        }
+
+        [TestMethod]
+        public void CreateFile_Exists()
+        {
+            Assert.IsFalse(FileSystem.Exists(RootFilePath));
+
+            // Place initial content.
+            using (var stream = FileSystem.CreateFile(RootFilePath))
+            {
+                stream.Write(Encoding.UTF8.GetBytes("asdf"));
+            }
+
+            Assert.IsTrue(FileSystem.Exists(RootFilePath));
+
+            // Replace—truncates.
+            var content = Encoding.UTF8.GetBytes("b");
+            using (var stream = FileSystem.CreateFile(RootFilePath))
+            {
+                stream.Write(content);
+            }
+
+            Assert.IsTrue(FileSystem.Exists(RootFilePath));
+            using (var stream = FileSystem.OpenFile(RootFilePath, FileAccess.Read))
+                CollectionAssert.AreEqual(content, stream.ReadAllBytes());
+        }
+
+        [TestMethod]
+        public void CreateFile_Empty()
+        {
+            using (var stream = FileSystem.CreateFile(RootFilePath))
+            {
+            }
+
+            Assert.IsTrue(FileSystem.Exists(RootFilePath));
+
+            using (var stream = FileSystem.OpenFile(RootFilePath, FileAccess.Read))
+            {
+                CollectionAssert.AreEqual(
+                    new byte[] { },
+                    stream.ReadAllBytes());
+            }
+        }
+
+        [TestMethod]
+        public void GetEntities()
+        {
+            for (var i = 0; i < 10; i++)
+            {
+                Console.WriteLine($"i={i}");
+                using (var stream = FileSystem.CreateFile(RootFilePath))
+                {
+                }
+
+                // Should exist once.
+                CollectionAssert.AreEquivalent(
+                    new[] { RootFilePath, },
+                    FileSystem.GetEntities(FileSystemPath.Root).ToArray());
+            }
+        }
+    }
+}

--- a/SharpFileSystem.Tests/FileSystems/PhysicalFileSystemTest.cs
+++ b/SharpFileSystem.Tests/FileSystems/PhysicalFileSystemTest.cs
@@ -1,0 +1,119 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SharpFileSystem.FileSystems;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace SharpFileSystem.Tests.FileSystems
+{
+    [TestClass]
+    public class PhysicalFileSystemTest
+    {
+        string Root { get; set; }
+        PhysicalFileSystem FileSystem { get; set; }
+        string AbsoluteFileName { get; set; }
+
+        string FileName { get; }
+        FileSystemPath FileNamePath { get; }
+
+        public PhysicalFileSystemTest()
+        {
+            FileName = "x";
+            FileNamePath = FileSystemPath.Root.AppendFile(FileName);
+        }
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            Root = Path.Combine(Path.GetFullPath("."), "TestRoot");
+            System.IO.Directory.CreateDirectory(Root);
+            AbsoluteFileName = Path.Combine(Root, FileName);
+            FileSystem = new PhysicalFileSystem(Root);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            using (FileSystem) { }
+            System.IO.Directory.Delete(Root, true);
+        }
+
+        [TestMethod]
+        public void CreateFile()
+        {
+            Assert.IsFalse(System.IO.File.Exists(AbsoluteFileName));
+            Assert.IsFalse(FileSystem.Exists(FileNamePath));
+
+            var content = Encoding.UTF8.GetBytes("asdf");
+            using (var stream = FileSystem.CreateFile(FileNamePath))
+            {
+                // File should exist at this point.
+                Assert.IsTrue(FileSystem.Exists(FileNamePath));
+                // File should also exist irl at this point.
+                Assert.IsTrue(System.IO.File.Exists(AbsoluteFileName));
+
+                stream.Write(content, 0, content.Length);
+            }
+
+            // File should contain content.
+            CollectionAssert.AreEqual(content, System.IO.File.ReadAllBytes(AbsoluteFileName));
+
+            using (var stream = FileSystem.OpenFile(FileNamePath, FileAccess.Read))
+            {
+                // Verify that EOF type stuff works.
+                var readContent = new byte[2 * content.Length];
+                Assert.AreEqual(content.Length, stream.Read(readContent, 0, readContent.Length));
+                CollectionAssert.AreEqual(
+                    content,
+                    // trim to actual length.
+                    readContent.Take(content.Length).ToArray());
+
+                // Trying to read beyond end of file should just return 0.
+                Assert.AreEqual(0, stream.Read(readContent, 0, readContent.Length));
+            }
+        }
+
+        [TestMethod]
+        public void CreateFile_Exists()
+        {
+            Assert.IsFalse(System.IO.File.Exists(AbsoluteFileName));
+            Assert.IsFalse(FileSystem.Exists(FileNamePath));
+
+            using (var stream = FileSystem.CreateFile(FileNamePath))
+            {
+                var content1 = Encoding.UTF8.GetBytes("asdf");
+                stream.Write(content1, 0, content1.Length);
+            }
+
+            // creating an existing file should truncate like open(O_CREAT).
+            var content2 = Encoding.UTF8.GetBytes("b");
+            using (var stream = FileSystem.CreateFile(FileNamePath))
+            {
+                stream.Write(content2, 0, content2.Length);
+            }
+            CollectionAssert.AreEqual(content2, System.IO.File.ReadAllBytes(AbsoluteFileName));
+            using (var stream = FileSystem.OpenFile(FileNamePath, FileAccess.Read))
+            {
+                CollectionAssert.AreEqual(content2, stream.ReadAllBytes());
+            }
+        }
+
+        [TestMethod]
+        public void CreateFile_Empty()
+        {
+            using (var stream = FileSystem.CreateFile(FileNamePath))
+            {
+            }
+
+            CollectionAssert.AreEqual(
+                new byte[] { },
+                System.IO.File.ReadAllBytes(AbsoluteFileName));
+            using (var stream = FileSystem.OpenFile(FileNamePath, FileAccess.Read))
+            {
+                CollectionAssert.AreEqual(
+                    new byte[] { },
+                    stream.ReadAllBytes());
+            }
+        }
+    }
+}

--- a/SharpFileSystem.Tests/SharpFileSystem.Tests.csproj
+++ b/SharpFileSystem.Tests/SharpFileSystem.Tests.csproj
@@ -64,6 +64,8 @@
   <ItemGroup>
     <Compile Include="AssertExtensions.cs" />
     <Compile Include="FileSystemPathTest.cs" />
+    <Compile Include="FileSystems\MemoryFileSystemTest.cs" />
+    <Compile Include="FileSystems\PhysicalFileSystemTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SharpZipLib\SharpZipLibFileSystemTest.cs" />
   </ItemGroup>

--- a/SharpFileSystem/FileSystems/MemoryFileSystem.cs
+++ b/SharpFileSystem/FileSystems/MemoryFileSystem.cs
@@ -8,20 +8,20 @@ namespace SharpFileSystem.FileSystems
 {
     public class MemoryFileSystem : IFileSystem
     {
-        private IDictionary<FileSystemPath, LinkedList<FileSystemPath>> _directories =
-    new Dictionary<FileSystemPath, LinkedList<FileSystemPath>>();
+        private IDictionary<FileSystemPath, ISet<FileSystemPath>> _directories =
+    new Dictionary<FileSystemPath, ISet<FileSystemPath>>();
         private IDictionary<FileSystemPath, MemoryFile> _files =
             new Dictionary<FileSystemPath, MemoryFile>();
         public MemoryFileSystem()
         {
-            _directories.Add(FileSystemPath.Root, new LinkedList<FileSystemPath>());
+            _directories.Add(FileSystemPath.Root, new HashSet<FileSystemPath>());
         }
 
         public ICollection<FileSystemPath> GetEntities(FileSystemPath path)
         {
             if (!path.IsDirectory)
                 throw new ArgumentException("The specified path is no directory.", "path");
-            LinkedList<FileSystemPath> subentities;
+            ISet<FileSystemPath> subentities;
             if (!_directories.TryGetValue(path, out subentities))
                 throw new DirectoryNotFoundException();
             return subentities;
@@ -38,7 +38,7 @@ namespace SharpFileSystem.FileSystems
                 throw new ArgumentException("The specified path is no file.", "path");
             if (!_directories.ContainsKey(path.ParentPath))
                 throw new DirectoryNotFoundException();
-            _directories[path.ParentPath].AddLast(path);
+            _directories[path.ParentPath].Add(path);
             return new MemoryFileStream(_files[path] = new MemoryFile());
         }
 
@@ -56,13 +56,13 @@ namespace SharpFileSystem.FileSystems
         {
             if (!path.IsDirectory)
                 throw new ArgumentException("The specified path is no directory.", "path");
-            LinkedList<FileSystemPath> subentities;
+            ISet<FileSystemPath> subentities;
             if (_directories.ContainsKey(path))
                 throw new ArgumentException("The specified directory-path already exists.", "path");
             if (!_directories.TryGetValue(path.ParentPath, out subentities))
                 throw new DirectoryNotFoundException();
-            subentities.AddLast(path);
-            _directories[path] = new LinkedList<FileSystemPath>();
+            subentities.Add(path);
+            _directories[path] = new HashSet<FileSystemPath>();
         }
 
         public void Delete(FileSystemPath path)


### PR DESCRIPTION
I thought I would fiddle around with exercising `PhysicalFileSystem` and `MemoryFileSystem` for a bit. These are the tests cases I came up with. I discovered that each `MemoryFileSystem.CreateFile()` call was creating a new entry in `GetEntities()`, so I added a fix to ensure that each file only gets listed once regardless of how many times it is created to better emulate real filesystems.